### PR TITLE
Comment out noisy console.warn

### DIFF
--- a/src/components/EdgesLayer.js
+++ b/src/components/EdgesLayer.js
@@ -73,7 +73,7 @@ export function traceEdges(
             });
         }
 
-        console.warn('HORZ', horizontalLineYCoords, endHeight, nodesByColumn, segments);
+        // console.log('HORZ', horizontalLineYCoords, endHeight, nodesByColumn, segments);
         return { segments, segmentsByColumnIdx };
     }
 
@@ -172,7 +172,7 @@ export function traceEdges(
             const { source: sB, target: tB } = edgeB;
             const colDifA = Math.abs(tA.colum - sA.column);
             const colDifB = Math.abs(tB.colum - sB.column);
-            
+
             // If just 1 col dif, move to front for intersection testing (tracing skipped)
             if (colDifA === 1 && colDifB === 1){
                 return 0;
@@ -405,4 +405,3 @@ const DebugVizGraphLayer = React.memo(function DebugVizGraphLayer({ segments, en
         </g>
     );
 });
-


### PR DESCRIPTION
This one statement is adding a lot of noise to the logs in my wrapper. (If you'd want a more general policy, I'd suggest eslint rules to only allow `.warn` and `.error`, and commenting out debugging `.log` calls, but this is the only one that's annoying me right now.)

(Other whitespace changes come for editor defaults.)