### PR TITLE
CSSTransition Updates to Fix findDOMNode Errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 - [View releases on NPM](https://www.npmjs.com/package/@hms-dbmi-bgm/react-workflow-viz?activeTab=versions)
 - [View releases on Unpkg](https://unpkg.com/browse/@hms-dbmi-bgm/react-workflow-viz/)
 
+#### 2024-08-27 (v0.1.11)
+- CSSTransition in Nodes and Edges was throwing the `findDOMNode is deprecated and will be removed in the next major release. Instead, add a ref directly to the element you want to reference.` during animations and transitions. Forwarding the referenced DOM element by nodeRef and ref props solved the issue.
+
 #### 2023-05-17 (v0.1.9)
 - No changes except `package-lock.json` + `package.json` version (new NPM release)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hms-dbmi-bgm/react-workflow-viz",
-  "version": "0.1.11-beta.0",
+  "version": "0.1.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hms-dbmi-bgm/react-workflow-viz",
-      "version": "0.1.11-beta.0",
+      "version": "0.1.11",
       "license": "MIT",
       "dependencies": {
         "memoize-one": "^5.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hms-dbmi-bgm/react-workflow-viz",
-  "version": "0.1.10",
+  "version": "0.1.11-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hms-dbmi-bgm/react-workflow-viz",
-      "version": "0.1.10",
+      "version": "0.1.11-beta.0",
       "license": "MIT",
       "dependencies": {
         "memoize-one": "^5.1.1",
@@ -21137,7 +21137,7 @@
       "dev": true,
       "requires": {
         "atob": "^2.1.2",
-        "decode-uri-component": "^0.2.2",
+        "decode-uri-component": "^0.2.0",
         "resolve-url": "^0.2.1",
         "source-map-url": "^0.4.0",
         "urix": "^0.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hms-dbmi-bgm/react-workflow-viz",
-  "version": "0.1.10",
+  "version": "0.1.11-beta.0",
   "description": "React component for visualizing CWL-like workflows and provenance graphs.",
   "main": "./dist/react-workflow-viz.min.js",
   "unpkg": "./dist/react-workflow-viz.min.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hms-dbmi-bgm/react-workflow-viz",
-  "version": "0.1.11-beta.0",
+  "version": "0.1.11",
   "description": "React component for visualizing CWL-like workflows and provenance graphs.",
   "main": "./dist/react-workflow-viz.min.js",
   "unpkg": "./dist/react-workflow-viz.min.js",

--- a/src/components/Edge.js
+++ b/src/components/Edge.js
@@ -390,7 +390,7 @@ export default class Edge extends React.Component {
             });
         }
 
-        const pathElem = this.pathRef.current; // Necessary if using alternate transition approach(es).
+        const pathElem = this.props.forwardedRef.current; // Necessary if using alternate transition approach(es).
         const changeTween = () =>
             (t) => {
                 const nextCoords = [
@@ -463,7 +463,7 @@ export default class Edge extends React.Component {
     }
 
     render(){
-        const { edge, pathArrows, style } = this.props;
+        const { edge, pathArrows, style, forwardedRef } = this.props;
         const { pathDimension } = this.state;
         const { disabled, selected, related, distantlySelected } = this.getComputedProperties();
         let markerEnd;
@@ -479,7 +479,7 @@ export default class Edge extends React.Component {
         }
 
         return (
-            <path d={pathDimension} ref={this.pathRef} className={"edge-path" + (disabled ? ' disabled' : '' )}
+            <path d={pathDimension} ref={forwardedRef} className={"edge-path" + (disabled ? ' disabled' : '' )}
                 data-edge-selected={selected || distantlySelected} data-edge-related={related}
                 data-source={edge.source.name} data-target={edge.target.name} style={style}
                 markerEnd={markerEnd && "url(#" + markerEnd + ")"} />

--- a/src/components/Edge.js
+++ b/src/components/Edge.js
@@ -271,10 +271,6 @@ export default class Edge extends React.Component {
         this.state = {
             'pathDimension' : this.generatePathDimension()
         };
-
-        // Alternative implementation of transition -
-        // adjust pathRef.current `d` attribute manually
-        this.pathRef = React.createRef();
     }
 
     getComputedProperties(props = this.props){

--- a/src/components/EdgesLayer.js
+++ b/src/components/EdgesLayer.js
@@ -367,8 +367,6 @@ export default class EdgesLayer extends React.PureComponent {
         this.sortedEdges = this.sortedEdges.bind(this);
         // Create refs for each node
         this.nodeRefs = {};
-        //this.getAllPathElements = this.getAllPathElements.bind(this);
-        //this.edgeRefs = [];
     }
 
     static edgeOnEnter(nodeRef) {
@@ -396,26 +394,9 @@ export default class EdgesLayer extends React.PureComponent {
     }
 
     sortedEdges = memoize(function(edges, selectedNodes, isNodeDisabled){
-        const nextEdges = EdgesLayer.sortedEdges(edges, selectedNodes, isNodeDisabled);
-        // Create new list of refs each time we're updated.
-        //this.edgeRefs = [];
-        //_.forEach(nextEdges, ()=>{
-        //    this.edgeRefs.push(React.createRef());
-        //});
+        const nextEdges = EdgesLayer.sortedEdges(edges, selectedNodes, isNodeDisabled);;
         return nextEdges;
     });
-
-    // Experimentation with transitioning multiple edges at once within requestAnimationFrame.
-    // Need to rethink design of this, an array for this.edgeRefs won't work as we need to keep
-    // state.source.x, state.source.y cached in state and associated w/ each edge.
-    // Possibly can use object keyed by 'key' string (as determined in render method).
-    // Keeping for reference.
-    //
-    //getAllPathElements(){
-    //    return _.map(this.edgeRefs, function(ref){
-    //        return ref && ref.current && ref.current.pathRef && ref.current.pathRef.current;
-    //    });
-    //}
 
     pathArrows(){
         if (!this.props.pathArrows) return null;

--- a/src/components/Node.js
+++ b/src/components/Node.js
@@ -96,21 +96,7 @@ export default class Node extends React.Component {
     static isSelected(currentNode, selectedNode){
         if (!selectedNode) return false;
         if (selectedNode === currentNode) return true;
-        /*
-        // We shouldn't need the below and can just rely on a simple reference comparison
-        // Keeping around for now/reference.
-        if (typeof selectedNode.name === 'string' && typeof currentNode.name === 'string') {
-            if (selectedNode.name === currentNode.name){
-                // Case: IO node (which would have add'l self-generated ID to ensure uniqueness)
-                if (typeof selectedNode.id === 'string'){
-                    if (selectedNode.id === currentNode.id) return true;
-                    return false;
-                }
-                return true;
-            }
-            return false;
-        }
-        */
+
         return false;
     }
 
@@ -230,7 +216,7 @@ export default class Node extends React.Component {
     }
 
     render(){
-        var { node, isNodeDisabled, className, columnWidth, renderNodeElement, selectedNode } = this.props,
+        var { node, isNodeDisabled, className, columnWidth, renderNodeElement, selectedNode, forwardedRef } = this.props,
             disabled         = typeof node.disabled !== 'undefined' ? node.disabled : this.isDisabled(node, isNodeDisabled),
             isCurrentContext = typeof node.isCurrentContext !== 'undefined' ? node.isCurrentContext : null,
             classNameList    = ["node", "node-type-" + node.nodeType],
@@ -258,7 +244,7 @@ export default class Node extends React.Component {
                     'left'      : node.x,
                     'width'     : columnWidth || 100,
                     'zIndex'    : 2 + (node.indexInColumn || 0)
-                }}>
+                }} ref={forwardedRef}>
                 <div className="inner" children={renderNodeElement(node, visibleNodeProps)}
                     {..._.pick(this.props, 'onMouseEnter', 'onMouseLeave')} onClick={disabled ? null : this.props.onClick} />
             </div>

--- a/src/components/NodesLayer.js
+++ b/src/components/NodesLayer.js
@@ -36,6 +36,7 @@ export default class NodesLayer extends React.PureComponent {
             countInActiveContext: memoize(NodesLayer.countInActiveContext),
             lastActiveContextNode: memoize(NodesLayer.lastActiveContextNode)
         };
+        this.nodeRefs = {};
     }
 
     renderNodeElements(){
@@ -59,9 +60,12 @@ export default class NodesLayer extends React.PureComponent {
                     'className'     : nodeClassName
                 }
             );
+            if (!this.nodeRefs[nodeProps.key]) {
+                this.nodeRefs[nodeProps.key] = React.createRef();
+            }
             return (
-                <CSSTransition classNames="workflow-node-transition" unmountOnExit timeout={500} key={nodeProps.key}>
-                    <Node {...nodeProps} />
+                <CSSTransition classNames="workflow-node-transition" unmountOnExit timeout={500} key={nodeProps.key} nodeRef={this.nodeRefs[nodeProps.key]}>
+                    <ForwardedNode {...nodeProps} ref={this.nodeRefs[nodeProps.key]} />
                 </CSSTransition>
             );
         });
@@ -83,3 +87,7 @@ export default class NodesLayer extends React.PureComponent {
     }
 
 }
+
+const ForwardedNode = React.forwardRef((props, ref) => {
+    return <Node {...props} forwardedRef={ref} />;
+});


### PR DESCRIPTION
npm release: [0.1.11-beta.0](https://www.npmjs.com/package/@hms-dbmi-bgm/react-workflow-viz/v/0.1.11-beta.0)

`CSSTransition` in Nodes and Edges throws the error below during animations and transitions:

`findDOMNode is deprecated and will be removed in the next major release. Instead, add a ref directly to the element you want to reference.`

Forwarding the referenced DOM element by `nodeRef` and `ref` props solved the issue.